### PR TITLE
Add --config/-c flag to allow usage of a json configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,15 @@ Converts txt and .md to plane html static site
 
 ## Features
 
-> So far, this tool has the following functions:
-
-- Allows the user to open a .txt file or .md file and generate a .html file.
-- Allow user to check the tool's version.
+| Command | Description |
+| ------- | ----------- |
+| `--help`/`-h` | Display the full list of features |
+| `--version`/`-v` | Check the tool version |
+| `--input`/`-i <INPUT_FILE_OR_FOLDER>` | Specify input file or folder |
+| `--output`/`-o <OUTPUT_FOLDER>` | Specify output folder (default is `./dist`) |
+| `--lang`/`-l <LANGUAGE_CODE>` | Specify language for output file(s) (default is `en`) |
+| `--encoding`/`-e <ENCODING_NAME>` | Specify character encoding (default is `utf-8`) |
+| `--config`/`-c <CONFIG_JSON_FILE>` | Load custom configuration from a JSON file |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Converts txt and .md to plane html static site
 
 ## Example
 
-> `python txt-to-html.py -i test2.md
+> `python txt-to-html.py -i test2.md`
 
-> `python txt-to-html.py -i test.txt
+> `python txt-to-html.py -i test.txt`
 

--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ Converts txt and .md to plane html static site
 
 1. Generate a .html file from a file or folder:
 
-   > ` python txt-to-html-converter.py -i/--input <file name or folder name>`
+   > ` python txt-to-html.py -i/--input <file name or folder name>`
 
 2. Check the tool's version
 
-   > ` python txt-to-html-converter.py –v/--version`
+   > ` python txt-to-html.py –v/--version`
 
 3. Display how to use the tool
-   > ` python txt-to-html-converter.py –h`
+   > ` python txt-to-html.py –h`
 
 ## Example
 
-> `python txt-to-html-converter.py -i test2.md
+> `python txt-to-html.py -i test2.md
 
-> ` python txt-to-html-converter.py -i test.txt
+> `python txt-to-html.py -i test.txt
 

--- a/txt-to-html.py
+++ b/txt-to-html.py
@@ -242,6 +242,6 @@ if __name__ == '__main__':
 
         create_html(outputName, Lines)
     
-    else:
+    elif not args.version:
         print("Invalid input")
         exit(-1)

--- a/txt-to-html.py
+++ b/txt-to-html.py
@@ -8,6 +8,7 @@ import argparse
 import os
 import sys
 
+import json
 import re
 
 
@@ -167,18 +168,26 @@ if __name__ == '__main__':
         '-l', '--language', help='specify language such as: en, ru ...', metavar='LANG')
     groupGeneral.add_argument(
         '-e', '--encoding', help="specify page encoding, such as utf-8", metavar='ENCODE')
+    groupGeneral.add_argument(
+        '-c', '--config', help='specify config file to be used, must be JSON format', metavar='CONFIG'
+    )
     args = parser.parse_args()
 
-    if args.version:
-        print("version: {}".format(versionNum))
-    if args.language:
-        lang = args.language
-    if args.encoding:
-        encode = args.encode
-    if args.output:
-        destDir += args.output
+    if args.config:
+        pass
+    else:
+        if args.version:
+            print("version: {}".format(versionNum))
+        if args.language:
+            lang = args.language
+        if args.encoding:
+            encode = args.encode
+        if args.output:
+            destDir += args.output
+        if args.input:
+            input = args.input
 
-    if args.input:    # TODO for multiple files can loop over them
+    if input:    # TODO for multiple files can loop over them
         """
             this is the main part of the program, where all html conversion happens
         """

--- a/txt-to-html.py
+++ b/txt-to-html.py
@@ -148,6 +148,7 @@ if __name__ == '__main__':
     destDir = './dist/'
     source_dir = "."
     out_dir = "."
+    input = None
 
     # here i am using argparse library, that will create help menu
     parser = argparse.ArgumentParser(
@@ -174,7 +175,21 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.config:
-        pass
+        configPath = args.config
+        if configPath == "" or not configPath.endswith(".json"):
+            print("Invalid config file! Currently only support one *.json file")
+            exit(-1)
+        with open(configPath, encoding=encode) as configFile:
+            configData = json.load(configFile)
+            for key in configData:
+                if key == 'input':
+                    input = configData[key]
+                elif key == 'output':
+                    destDir = configData[key]
+                elif key == 'language' or key == 'lang':
+                    lang = configData[key]
+                elif key == 'encode' or key == 'encoding':
+                    encode = configData[key]
     else:
         if args.version:
             print("version: {}".format(versionNum))
@@ -187,13 +202,13 @@ if __name__ == '__main__':
         if args.input:
             input = args.input
 
-    if input:    # TODO for multiple files can loop over them
+    if input and len(input) > 0:    # TODO for multiple files can loop over them
         """
             this is the main part of the program, where all html conversion happens
         """
-        print("file name is {}".format(args.input))
+        print("file name is {}".format(input))
 
-        title = args.input
+        title = input
         outputName = destDir + title + ".html"
 
         Lines = ["<doctype html>",
@@ -226,3 +241,7 @@ if __name__ == '__main__':
 
 
         create_html(outputName, Lines)
+    
+    else:
+        print("Invalid input")
+        exit(-1)


### PR DESCRIPTION
### Changes made: 
#### Related to issue #10:
- Added `--config`/`-c` flag to `argparse`
- Program now ignore other arguments if --config/-c is present
- Invalid config files (currently only accept `.json`) will produce an error message & exit with code -1
- Program now parse the data from a valid config file and extract the appropriate options
- Added documentation for `--config/-c` flag in [README.md](https://github.com/Loran-l/txt-to-html-converter/blob/main/README.md)
#### Other minor changes:
- Fixed command typo in [README.md](https://github.com/Loran-l/txt-to-html-converter/blob/main/README.md)
  - `python txt-to-html.py ...` instead of `python txt-to-html-converter.py ...`